### PR TITLE
fix dist exists error and buckets undefined error

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -13,6 +13,7 @@ const pckg = require('../package.json');
 
 const baseDir = process.cwd();
 const kesFolder = path.join(baseDir, '.kes');
+const distFolder = path.join(baseDir, 'dist');
 require('./readme');
 
 const success = (r) => process.exit(0);
@@ -59,15 +60,26 @@ const init = function () {
       process.exit(1);
     }
 
-    console.log(kesFolder);
     fs.mkdirSync(kesFolder);
-    fs.mkdirSync(path.join(baseDir, 'dist'));
+
+    // only create dist folder if it doesn't exist
+    try {
+      fs.statSync(distFolder)
+    } catch (e) {
+      fs.mkdirSync(distFolder);
+    }
+
     console.log(`.kes folder created at ${kesFolder}`);
 
     // copy simple config file and template
     const config = yaml.safeLoad(fs.readFileSync(
       path.join(__dirname, '..', 'examples/lambdas/config.yml'), 'utf8'));
     config.default.stackName = result.stack;
+
+    if (!config.default.buckets) {
+      config.default.buckets = {};
+    }
+
     config.default.buckets.internal = result.bucket;
     fs.writeFileSync(path.join(kesFolder, 'config.yml'), yaml.safeDump(config));
 


### PR DESCRIPTION
This is a PR against the v1.0 branch to fix a couple small issues I found running `kes init`.

The default buckets property threw an undefined error. I changed this to make `config.default.buckets` and empty object if it doesn't exist.

If a dist directory already existed it would throw an error. I changed this to only create the dist directory if it doesn't already exist.