### PR TITLE
Catch uncaught error

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,9 @@ function buildNestedCfs(config, KesClass, options) {
         config.nested_templates[name].url = uri;
       });
     }));
-    return Promise.all(ps).then(() => config);
+    return Promise.all(ps)
+      .then(() => config)
+      .catch(utils.failure);
   }
   return Promise.resolve(config);
 }


### PR DESCRIPTION
When running `kes cf deploy`, I got the following error:

```
Nested templates are found!
Compiling nested template for ApiDefault
Compiling nested template for ApiV1
(node:9077) UnhandledPromiseRejectionWarning: Error: connect EHOSTDOWN 169.254.169.254:80 - Local (10.0.0.9:65012)
    at Object._errnoException (util.js:1022:11)
    at _exceptionWithHostPort (util.js:1044:20)
    at internalConnect (net.js:976:16)
    at defaultTriggerAsyncIdScope (internal/async_hooks.js:283:19)
    at net.js:1074:9
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
(node:9077) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejec
ting a promise which was not handled with .catch(). (rejection id: 1)
(node:9077) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process w
ith a non-zero exit code.
```

The promise was being rejected but not caught.  Now catching that rejection.