### PR TITLE
Support proxy+ resource by removing non-alphanumeric characters from …

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 ## v2.2.2
-- support plus and minus apigateway urls
+- allow plus in the apigateway path to support the new proxy resource
 
 ## v2.2.1
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+## v2.2.2
+- support plus and minus apigateway urls
+
 ## v2.2.1
 
 - fix a bug where `config.bucket` was set as object when the config did not include a string

--- a/examples/template/config.yml
+++ b/examples/template/config.yml
@@ -79,6 +79,7 @@ default:
           api: myApi
         - path: '{proxy+}'
           method: any
+          api: myApi
     - name: Lambda1
       handler: index.handler
       timeout: 300

--- a/examples/template/config.yml
+++ b/examples/template/config.yml
@@ -77,6 +77,8 @@ default:
           method: post
           cors: true
           api: myApi
+        - path: '{proxy+}'
+          method: any
     - name: Lambda1
       handler: index.handler
       timeout: 300

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kes",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Making deployment to AWS using CloudFormation easier and fun",
   "scripts": {
     "html-docs": "documentation build bin/cli.js -f html -o _docs --theme node_modules/documentation-devseed-theme",

--- a/src/config.js
+++ b/src/config.js
@@ -133,9 +133,9 @@ class Config {
               let parents = [];
 
               // when a segment includes a variable, e.g. {short_name}
-              // we remove the curly braces and underscores and add Var to the name
+              // we remove the non-alphanumeric characters and add Var to the name
               if (startsWith(segment, '{')) {
-                name = `${replace(trim(segment, '{}'), '_', '')}Var`;
+                name = `${replace(segment, /\W/g, '')}Var`;
               }
 
               name = upperFirst(name);


### PR DESCRIPTION
…the resource name

This is to support {proxy+} as an API Gateway path i.e.: 
```
ApiDistribution:
  handler: index.distribution
  timeout: 20
  memory: 256
  source: 'node_modules/@cumulus/api/dist/'
  apiRole: true
  urs: true
  envs:
    EARTHDATA_BASE_URL: '{{parent.urs_url}}' 
    EARTHDATA_CLIENT_ID: '{{EARTHDATA_CLIENT_ID}}'
    EARTHDATA_CLIENT_PASSWORD: '{{EARTHDATA_CLIENT_PASSWORD}}'
  apiGateway:
    - api: distribution
      path: 'redirect'
      method: get
    - api: distribution
      path: '{proxy+}'
      method: any
```