### PR TITLE
support sub-params accessed by template basename

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Changed `Config` to store the basename of the `--template` option's path.
+- Added change to `cloudFormation()` to support multiple templates with one config file, by allowing
+  parameters to be nested under `template.baseName` keys. Backwards-compatible.
+
 ## v2.2.8
 
 - Changed `utils.determineKesClass()` to throw errors when Kes class override files are found, but cannot be loaded

--- a/src/config.js
+++ b/src/config.js
@@ -57,6 +57,7 @@ class Config {
       const templatePath = get(options, 'template');
       fs.lstatSync(templatePath);
       this.template = {
+        baseName: path.basename(templatePath),
         kesFolder: templatePath,
         configFile: path.join(templatePath, 'config.yml'),
         cfFile: path.join(templatePath, 'cloudformation.template.yml')

--- a/src/kes.js
+++ b/src/kes.js
@@ -248,24 +248,19 @@ class Kes {
    */
   cloudFormation() {
     const cfParams = [];
+    const pushToCfParams = (p) => {
+      cfParams.push({
+        ParameterKey: p.name,
+        ParameterValue: p.value,
+        UsePreviousValue: p.usePrevious || false
+      });
+    };
     // add custom params from the config file if any
     if (this.config.params[this.config.template.baseName]) {
-      this.config.params[this.config.template.baseName].forEach((p) => {
-        cfParams.push({
-          ParameterKey: p.name,
-          ParameterValue: p.value,
-          UsePreviousValue: p.usePrevious || false
-        });
-      });
+      this.config.params[this.config.template.baseName].forEach(pushToCfParams);
     }
     else if (this.config.params) {
-      this.config.params.forEach((p) => {
-        cfParams.push({
-          ParameterKey: p.name,
-          ParameterValue: p.value,
-          UsePreviousValue: p.usePrevious || false
-        });
-      });
+      this.config.params.forEach(pushToCfParams);
     }
 
     const capabilities = get(this.config, 'capabilities', []);

--- a/src/kes.js
+++ b/src/kes.js
@@ -259,7 +259,7 @@ class Kes {
     if (this.config.params[this.config.template.baseName]) {
       this.config.params[this.config.template.baseName].forEach(pushToCfParams);
     }
-    else if (this.config.params) {
+    else if (this.config.params && this.config.params instanceof Array) {
       this.config.params.forEach(pushToCfParams);
     }
 

--- a/src/kes.js
+++ b/src/kes.js
@@ -249,7 +249,17 @@ class Kes {
   cloudFormation() {
     const cfParams = [];
     // add custom params from the config file if any
-    if (this.config.params) {
+    if (this.config.params[this.config.template.baseName]) {
+      this.config.params[this.config.template.baseName].forEach((p) => {
+        cfParams.push({
+          ParameterKey: p.name,
+          ParameterValue: p.value,
+          UsePreviousValue: p.usePrevious || false
+          //NoEcho: p.noEcho || true
+        });
+      });
+    }
+    else if (this.config.params) {
       this.config.params.forEach((p) => {
         cfParams.push({
           ParameterKey: p.name,

--- a/src/kes.js
+++ b/src/kes.js
@@ -255,7 +255,6 @@ class Kes {
           ParameterKey: p.name,
           ParameterValue: p.value,
           UsePreviousValue: p.usePrevious || false
-          //NoEcho: p.noEcho || true
         });
       });
     }
@@ -265,7 +264,6 @@ class Kes {
           ParameterKey: p.name,
           ParameterValue: p.value,
           UsePreviousValue: p.usePrevious || false
-          //NoEcho: p.noEcho || true
         });
       });
     }


### PR DESCRIPTION
Addresses issue with non-shareable params when using one base config file for multiple stacks, by allowing `config.params` to contain sub-objects which match the `--template` path basename, e.g.:

Deploy command:
```kes cf deploy --template path/to/mytemp [...]```

Config.yml
```yaml
params:
  mytemp:
    - name: SomeParam
      value: SomeValue
```