### PR TITLE
Add an option to not roll back a stack when it fails to create

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -107,6 +107,7 @@ program
   .option('--stack <stack>', 'stack name, defaults to the config value')
   .option('--showOutputs', 'Show the list of a CloudFormation template outputs')
   .option('--yes', 'Skip all confirmation prompts')
+  .option('--noRollback', 'Don\'t delete Cloudformation stacks that fail to deploy')
   .option('-d, --deployment <deployment>', 'Deployment name, default to default');
 
 program

--- a/bin/readme.js
+++ b/bin/readme.js
@@ -31,6 +31,7 @@
  *  --showOutputs                  Show the list of a CloudFormation template outputs
  *  --yes                          Skip all confirmation prompts
  *  -d, --deployment <deployment>  Deployment name, default to default
+ *  --noRollback                 Don't delete Cloudformation stacks that fail to deploy
  *  -h, --help                    output usage information
  *
  *  Commands:

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,6 +36,7 @@
 -   [configureAws](#configureaws)
 -   [fileToString](#filetostring)
 -   [mergeYamls](#mergeyamls)
+-   [loadKesOverride](#loadkesoverride)
 -   [determineKesClass](#determinekesclass)
 -   [failure](#failure)
 -   [success](#success)
@@ -417,6 +418,20 @@ replace values of file 1 if they have the same key.
 -   `file2` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Yaml path to file 2 or file 2 string
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Merged Yaml file in string format
+
+## loadKesOverride
+
+Attempt to load a Kes override class.
+
+Throw the error if it is something other than that the Kes override
+class does not exist.
+
+**Parameters**
+
+-   `kesFolder` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The folder to look in for a Kes override class
+-   `kesClass` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The path/filename to look for as a Kes override class (optional, default `'kes.js'`)
+
+Returns **Class** A Kes override class
 
 ## determineKesClass
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@ It makes it much easier to deploy lambda functions and create API gateway resour
  --showOutputs                  Show the list of a CloudFormation template outputs
  --yes                          Skip all confirmation prompts
  -d, --deployment <deployment>  Deployment name, default to default
+ --noRollback                 Don't delete Cloudformation stacks that fail to deploy
  -h, --help                    output usage information
 
  Commands:

--- a/src/config.js
+++ b/src/config.js
@@ -50,6 +50,7 @@ class Config {
     this.stack = get(options, 'stack', null);
     this.parent = get(options, 'parent', null);
     this.showOutputs = get(options, 'showOutputs', false);
+    this.noRollback = get(options, 'noRollback', false);
     this.yes = get(options, 'yes', false);
 
     // use template if provided

--- a/src/kes.js
+++ b/src/kes.js
@@ -293,6 +293,9 @@ class Kes {
       .catch(e => {
         if (e.message.includes('does not exist')) {
           wait = 'stackCreateComplete';
+          
+          params.OnFailure = 'DO_NOTHING';
+          
           return this.cf.createStack(params).promise();
         }
         throw e;

--- a/src/kes.js
+++ b/src/kes.js
@@ -294,7 +294,9 @@ class Kes {
         if (e.message.includes('does not exist')) {
           wait = 'stackCreateComplete';
           
-          params.OnFailure = 'DO_NOTHING';
+          if (this.config.envs.NO_ROLLBACK) {
+            params.OnFailure = 'DO_NOTHING';
+          }
           
           return this.cf.createStack(params).promise();
         }

--- a/src/kes.js
+++ b/src/kes.js
@@ -293,8 +293,8 @@ class Kes {
       .catch(e => {
         if (e.message.includes('does not exist')) {
           wait = 'stackCreateComplete';
-          
-          if (this.config.envs.NO_ROLLBACK) {
+
+          if (this.config.noRollback) {
             params.OnFailure = 'DO_NOTHING';
           }
           


### PR DESCRIPTION
This is useful to inspect resources in their failed state (e.g. for log extraction)