### PR TITLE
Fixes #81 - missing error information when running examples

### DIFF
--- a/src/kes.js
+++ b/src/kes.js
@@ -170,6 +170,8 @@ class Kes {
       const destPath = path.join(this.config.kesFolder, this.cf_template_name);
       console.log(`Template saved to ${destPath}`);
       return fs.writeFileSync(destPath, cf);
+    }).catch((e) => {
+      console.log(e);
     });
   }
 

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -134,7 +134,13 @@ class Lambda {
       s3.headObject({
         Bucket: this.bucket,
         Key: lambda.remote
-      }).promise().then((data) => {
+      }).promise().catch(
+          (e) => {
+            console.log('Error uploading lambda to: ' + params.Bucket + '/' + params.Key);
+
+            throw e;
+          }
+      ).then((data) => {
         if (data.ContentLength !== params.Body.byteLength) {
           throw new Error('File sizes don\'t match');
         }


### PR DESCRIPTION
This lets you see the stack traces that come out of the AWS SDK. Unfortunately it doesn't show you the caller because the stack traces stop at the promise boundary. 

If I run across another issue like this I'll make another PR - using async/await on the AWS promises might improve things, but that looks like a more involved change..